### PR TITLE
Add star option for ctables

### DIFF
--- a/R/latex.s
+++ b/R/latex.s
@@ -348,6 +348,7 @@ latex.default <-
            longtable=FALSE, draft.longtable=TRUE, ctable=FALSE, booktabs=FALSE,
            table.env=TRUE, here=FALSE, lines.page=40,
            caption=NULL, caption.lot=NULL, caption.loc=c('top','bottom'),
+           star=FALSE,
            double.slash=FALSE,
            vbar=FALSE, collabel.just=rep("c",nc), na.blank=TRUE,
            insert.bottom=NULL, insert.bottom.width=NULL,
@@ -631,6 +632,7 @@ latex.default <-
             if(length(caption.lot))
             paste('cap={', caption.lot, '},', sep=''),
             paste('label=', label, ',', sep=''),
+            if (star) "star, ", 
             if(!landscape)
             paste('pos=', where, ',', sep=''),
             if(landscape) 'sideways',

--- a/man/latex.Rd
+++ b/man/latex.Rd
@@ -111,6 +111,7 @@ latex(object, \dots)
     longtable=FALSE, draft.longtable=TRUE, ctable=FALSE, booktabs=FALSE,
     table.env=TRUE, here=FALSE, lines.page=40,
     caption=NULL, caption.lot=NULL, caption.loc=c('top','bottom'),
+    star=FALSE,
     double.slash=FALSE,
     vbar=FALSE, collabel.just=rep("c",nc), na.blank=TRUE,
     insert.bottom=NULL, insert.bottom.width=NULL,
@@ -397,6 +398,10 @@ dvigv(object, \dots)
   \item{caption.loc}{
     set to \code{"bottom"} to position a caption below
     the table instead of the default of \code{"top"}.
+  }
+  \item{star}{
+    apply the star option for ctables to allow a table to spread over
+    two columns when in twocolumn mode.
   }
   \item{double.slash}{
     set to \code{TRUE} to output \samp{"\\"} as \samp{"\\\\"} in LaTeX commands. Useful when you


### PR DESCRIPTION
ctables have a star option to allow tables to spread over two columns when the latex document is in \twocolumn mode. This commit adds this option to latex.default and the Rd page. 
