### PR TITLE
format.df - passing "..."

### DIFF
--- a/R/latex.s
+++ b/R/latex.s
@@ -54,6 +54,8 @@ first.word <- function(x, i=1, expr=substitute(x))
 ##    27May02 - added booktabs FEH
 ## 13Dec02 - added ctable   FEH
 ## arguments included check.names=TRUE 23jan03
+##
+## 16Jan15 (A. Kiermeier) pass "..." to formt() and format()
 
 format.df <- function(x,
                       digits, dec=NULL, rdec=NULL, cdec=NULL,
@@ -113,8 +115,9 @@ format.df <- function(x,
   }
   
   formt <- function(x, decimal.mark='.', nsmall=0,
-                    scientific=c(-4,4), digits=NULL, na.blank=FALSE) {
-    y <- format(x, nsmall=nsmall, decimal.mark=decimal.mark, digits=digits)
+                    scientific=c(-4,4), digits=NULL, na.blank=FALSE, ...) {
+    y <- format(x, nsmall=nsmall, decimal.mark=decimal.mark,
+                digits=digits, ...)
     if(decimal.mark!='.') y <- gsub('\\.', decimal.mark, y)
     if(na.blank) y <- ifelse(is.na(x), '', y)
     y
@@ -251,26 +254,27 @@ format.df <- function(x,
 
         if(rtype == 1)
           cxk <- formt(xk, decimal.mark=dot, scientific=scientific,
-                       digits=digits, na.blank=na.blank)
+                       digits=digits, na.blank=na.blank, ...)
         else if(rtype == 3) {
           cxk <- character(nrx)
           for(i in 1:nrx)
             cxk[i] <-
               if(is.na(dec[i,j]))
                 formt(xk[i], decimal.mark=dot, scientific=scientific,
-                      digits=digits, na.blank=na.blank)
+                      digits=digits, na.blank=na.blank, ...)
               else
                 formt(round(xk[i], dec[i,j]), decimal.mark=dot,
                       digits=digits, nsmall=dec[i,j], scientific=scientific,
-                      na.blank=na.blank)
+                      na.blank=na.blank, ...)
         } else if(rtype == 4)
           cxk <-
             if(is.na(cdec[j]))
               formt(xk, decimal.mark=dot, scientific=scientific, digits=digits,
-                    na.blank=na.blank)
+                    na.blank=na.blank, ...)
             else
               formt(round(xk, cdec[j]), decimal.mark=dot, nsmall=cdec[j],
-                    digits=digits, scientific=scientific, na.blank=na.blank)
+                    digits=digits, scientific=scientific,
+                    na.blank=na.blank, ...)
         
         if(na.dot)
           cxk[is.na(xk)] <- '.'  # SAS-specific

--- a/man/format.df.Rd
+++ b/man/format.df.Rd
@@ -137,8 +137,9 @@ format.df(x, digits, dec=NULL, rdec=NULL, cdec=NULL,
     String used to format objects of the POSIXt class.
   }
   \item{\dots}{
-    other arguments are accepted and ignored.  For \code{latexVerbatim} these
-    arguments are passed to the \code{print} function.
+    other arguments are accepted and passed to \code{format.default}.
+    For \code{latexVerbatim} these arguments are passed to the
+    \code{print} function.
   }
 }
 \value{
@@ -179,11 +180,11 @@ format.df(x, digits, dec=NULL, rdec=NULL, cdec=NULL,
 \examples{
 \dontrun{
 x <- data.frame(a=1:2, b=3:4)
-x$m <- matrix(5:8,nrow=2)
+x$m <- 10000*matrix(5:8,nrow=2)
 names(x)
 dim(x)
 x
-format.df(x)
+format.df(x, big.mark=",")
 dim(format.df(x))
 }
 }


### PR DESCRIPTION
The "..." argument of format.df is no longer ignored, but included in
the definition of formt() and passed to format(). The help file has also
been updated and the example modified to show an example of big.mark.