### PR TITLE
Simplified consolidate<- to work with byte-code compiler

### DIFF
--- a/R/consolidate.s
+++ b/R/consolidate.s
@@ -5,9 +5,8 @@ consolidate <- function(x, value, protect, ...) {
   UseMethod("consolidate")
 }
 
-'consolidate<-' <- function(x, protect, ..., value)
-  eval.parent(replace(match.call(expand.dots=FALSE), list=1,
-                      values=list(as.name("consolidate"))))
+'consolidate<-' <- function(x, protect=FALSE, ..., value)
+  consolidate(x, value, protect, ...)
 
 consolidate.default <- function(x, value, protect=FALSE, ...) {
   if(missing(x) || is.null(x))


### PR DESCRIPTION
I changed "consolidate<-" to call directly to "consolidate". I've checked this with CRAN/BIOC packages that use Hmisc (yet in an older version of Hmisc) and it seems to be working fine. Also Hmisc check seems fine.

The reason for this is to avoid "eval" in the parent frame of the same call, obtained by "match.call". This original approach does not work with the byte-code compiler, which does not create the '*tmp*' temporary variable for assignment calls, but only a pre-evaluated promise with '*tmp*' given as expression in that promise. Ideally R programs should not rely on implementation details of the assignment calls, which are subject to change; in particular, the implementation in the interpreter may soon be modified to match the one in the compiler, which is more robust in complex assignment calls.