### PR TITLE
Add 'reencode' parameter to spss.get

### DIFF
--- a/R/misc.get.s
+++ b/R/misc.get.s
@@ -3,7 +3,8 @@ spss.get <- function(file, lowernames=FALSE,
                      use.value.labels=TRUE,
                      to.data.frame=TRUE,
                      max.value.labels=Inf,
-                     force.single=TRUE, allow=NULL, charfactor=FALSE) {
+                     force.single=TRUE, allow=NULL, charfactor=FALSE,
+                     reencode=NA) {
   if(length(grep('http://', file))) {
     tf <- tempfile()
     download.file(file, tf, mode='wb', quiet=TRUE)
@@ -12,7 +13,8 @@ spss.get <- function(file, lowernames=FALSE,
     
   w <- read.spss(file, use.value.labels=use.value.labels,
                  to.data.frame=to.data.frame,
-                 max.value.labels=max.value.labels)
+                 max.value.labels=max.value.labels,
+                 reencode=reencode)
   
   a   <- attributes(w)
   vl  <- a$variable.labels

--- a/man/spss.get.Rd
+++ b/man/spss.get.Rd
@@ -15,7 +15,7 @@ variables.  By default, underscores in names are converted to periods.
 spss.get(file, lowernames=FALSE, datevars = NULL,
          use.value.labels = TRUE, to.data.frame = TRUE,
          max.value.labels = Inf, force.single=TRUE,
-         allow=NULL, charfactor=FALSE)
+         allow=NULL, charfactor=FALSE, reencode = NA)
 }
 \arguments{
   \item{file}{input SPSS save file.  May be a file on the WWW, indicated
@@ -37,6 +37,7 @@ spss.get(file, lowernames=FALSE, datevars = NULL,
   \item{charfactor}{set to \code{TRUE} to change character variables to
 	factors if they have fewer than n/2 unique values.  Blanks and null
 	strings are converted to \code{NA}s.}
+  \item{reencode}{see \code{\link[foreign]{read.spss}}}
 }
 \value{
   a data frame or list


### PR DESCRIPTION
Currently, `spss.get` does not provide a means for setting the `reencode` parameter of `read.spss` from `foreign`. This causes character encoding issues when loading an UTF-8 encoded SPSS file on Windows. 

This fix solves said issue, allowing users to specify the charset to convert from.