### PR TITLE
Support for argument pass through for axis()

### DIFF
--- a/R/minor.tick.s
+++ b/R/minor.tick.s
@@ -1,5 +1,5 @@
-minor.tick <- function (nx = 2, ny = 2, tick.ratio = 0.5) {
-  ax <- function(w, n, tick.ratio) {
+minor.tick <- function (nx = 2, ny = 2, tick.ratio = 0.5, x.args = list(), y.args = list()) {
+  ax <- function(w, n, tick.ratio, add.args) {
     range <- par("usr")[if (w == "x") 1 : 2  else 3 : 4]
     tick.pos <- if (w == "x") par("xaxp") else par("yaxp")
     distance.between.minor <- (tick.pos[2] - tick.pos[1])/tick.pos[3]/n
@@ -15,13 +15,15 @@ minor.tick <- function (nx = 2, ny = 2, tick.ratio = 0.5) {
                   max(possible.minors[hi.candidates])
                 else
                   tick.pos[2]
-    axis(if (w == "x") 1 else 2,
-         seq(low.minor, hi.minor, by = distance.between.minor), 
-         labels = FALSE, tcl = par("tcl") * tick.ratio)
+    axis.args <- c(list(if (w == "x") 1 else 2,
+                        seq(low.minor, hi.minor, by = distance.between.minor), 
+                        labels = FALSE, tcl = par("tcl") * tick.ratio),
+                        add.args);
+	do.call(axis, axis.args);
     }
   if (nx > 1) 
-    ax("x", nx, tick.ratio = tick.ratio)
+    ax("x", nx, tick.ratio = tick.ratio, x.args)
   if (ny > 1) 
-    ax("y", ny, tick.ratio = tick.ratio)
+    ax("y", ny, tick.ratio = tick.ratio, y.args)
   invisible()
 }

--- a/man/minor.tick.Rd
+++ b/man/minor.tick.Rd
@@ -6,7 +6,7 @@ Adds minor tick marks to an existing plot.  All minor tick marks that
 will fit on the axes will be drawn.
 }
 \usage{
-minor.tick(nx=2, ny=2, tick.ratio=0.5)
+minor.tick(nx=2, ny=2, tick.ratio=0.5, x.args = list(), y.args = list())
 }
 \arguments{
 \item{nx}{
@@ -14,12 +14,16 @@ number of intervals in which to divide the area between major tick marks on
 the X-axis.  Set to 1 to suppress minor tick marks.
 }
 \item{ny}{
-same as \code{nx} but for the Y-axis
+same as \code{nx} but for the Y-axis.
 }
 \item{tick.ratio}{
 ratio of lengths of minor tick marks to major tick marks.  The length
-of major tick marks is retrieved from \code{par("tck")}.
-}}
+of major tick marks is retrieved from \code{par("tck")}.}
+\item{x.args}{
+additionl arguments (e.g. \code{post}, \code{lwd}) used by \code{axis()} function when rendering the X-axis.}
+\item{y.args}{
+same as \code{x.args} but for Y-axis.}
+}
 \section{Side Effects}{
 plots
 }


### PR DESCRIPTION
I came across this package as a recommendation to put minor tick marks on axes at [http://www.statmethods.net/advgraphs/axes.html]. I found `minor.ticks()` great, but my graphs needed a little more customization. I noticed that this could easily be implemented, by adding two more optional arguments, one for each axis. I implemented these minor changes and updated the documentation in my fork, here I suggest to pull these changes, because it adds functionality without the expense of breaking compatibility.

_For future versions_
I also propose here an alternative to the `minor.tick()` function, which would essentially implement the interface that `axis()` and `axTicks()` use. To avoid confusion and retain compatibility I propose the name `add.minor()` and it could be called as follows `add.minor(side, n, ...)`. This function would implement most of what is included currently in `minor.ticks()`, but with the ability to customize the axes through the standard `axis()` arguments. This function could also be used within the current `minor.ticks()` function in place of the current `ax()` sub-function so that the code base would only need updates in one place.