### PR TITLE
did not work when letters after the first had capitals

### DIFF
--- a/R/capitalize.s
+++ b/R/capitalize.s
@@ -1,7 +1,5 @@
 capitalize <- function(string) {
-  capped <- grep('^[^A-Z]*$', string, perl=TRUE)
-
-  substr(string[capped], 1,1) <- toupper(substr(string[capped], 1,1))
+  capped <- grep("^[A-Z]", string, invert = TRUE)
+  substr(string[capped], 1, 1) <- toupper(substr(string[capped], 1, 1))
   return(string)
 }
-


### PR DESCRIPTION
Previously, the example returned:

```{r}
capitalize(c("Hello", "bob", "daN"))
# "Hello" "Bob"   "daN" 
```

The capital `N` in `daN` seemed to be problematic. 

The desired behaviour should now be:

```{r}
capitalize(c("Hello", "bob", "daN"))
# "Hello" "Bob"   "DaN" 
```