### PR TITLE
[.pBlock() only retains the pBlock class if the result is a matrix

### DIFF
--- a/R/ynbind.s
+++ b/R/ynbind.s
@@ -71,8 +71,10 @@ structure(W, label=label, labels=lab, class=c('pBlock', 'matrix'))
   d <- dim(x)
   at <- attributes(x)[c('label', 'labels')]
   x <- NextMethod('[')
-  at$labels <- at$labels[cols]
-  attributes(x) <- c(attributes(x), at)
-  class(x) <- 'pBlock'
+  if (is.matrix(x)) {
+    at$labels <- at$labels[cols]
+    attributes(x) <- c(attributes(x), at)
+    class(x) <- 'pBlock'
+  }
   x
   }


### PR DESCRIPTION
I made a change to R where `factor()` uses `order()` instead of `sort.list()` when generating the levels. Thus, `table(pBlock)` ends up calling `rank()`, which does `x[!nas]` and `[.pBlock` yields an invalid object, since the result is a vector, not a matrix. That causes problems later.

This change makes it so `[.pBlock` just returns a vector when the result of the call to base `[` is not a matrix.