### PR TITLE
fix double replacement of ampersand in latex.summary.formula.reverse() and latex.summaryM()

### DIFF
--- a/R/summary.formula.s
+++ b/R/summary.formula.s
@@ -1907,8 +1907,7 @@ latex.summary.formula.reverse <-
   if(!length(gl))
     gl <- " "
 
-  lab <- sedit(lab,c(" ","&"),c("~","\\&"))
-  lab <- latexTranslate(lab, greek=TRUE)
+  lab <- latexTranslate(lab, c(" "), c("~"), greek=TRUE)
   gl  <- latexTranslate(gl, greek=TRUE)
   extracolheads <-
     if(any(gl != " "))

--- a/R/summaryM.s
+++ b/R/summaryM.s
@@ -725,8 +725,7 @@ latex.summaryM <-
     if(!length(gl)) gl <- " "
 
     if(! html) {
-      lab <- sedit(lab, c(" ", "&"), c("~", "\\&"))
-      lab <- latexTranslate(lab, greek=TRUE)
+      lab <- latexTranslate(lab, c(" "), c("~"), greek=TRUE)
       gl  <- latexTranslate(gl,  greek=TRUE)
       }
 


### PR DESCRIPTION
Both latex.summary.formula.reverse() and latex.summaryM() use sedit() to replace ampersands in labels with "\&" and then call latexTranslate(), which replaces the ampersand again, resulting in "\\&" (backslash-backslash-ampersand) being written to the LaTeX output, i.e., an escaped backslash and an unescaped ampersand, causing an error.

This pull request eliminates the unnecessary first replacement of the ampersand, keeping the call to latexTranslate(), which is sufficient.