### PR TITLE
insert spaces between multiple entries in bottom index in latex tables

### DIFF
--- a/R/latex.s
+++ b/R/latex.s
@@ -648,7 +648,7 @@ latex.default <-
         insert=list(if(! table.env && length(insert.bottom))
                       list('tabular', 'after', paste('\\par', insert.bottom)),
                     if(table.env)
-                      list('table',   'before', insert.bottom),
+                      list('table',   'before', paste(insert.bottom, collapse = ' ')),
                     if(caption.loc == 'bottom' && length(caption))
                       list('tabular', 'after', caption)
                    ) )


### PR DESCRIPTION
Currently, when `latex.summary.formula.reverse()` has multiple items in its legend (e.g., when test = TRUE and there are categorical and continuous variables present), these are pasted together without spaces. For example: "the upper quartile $c$\ for continuous variables.Numbers after percents are frequencies" (note, no space after the end of the first sentence).

Reproducible example:
```
library(Hmisc)

test <- data.frame(a = 1:50, b = rep(c('a', 'b'), 25), c = rep(c('c', 'd'), 25))

latex(summary(b ~ a + c, data = test, method = 'reverse', test = TRUE), file = "")
```
This pull request modifies `latex.default()` to `paste()` together the entries with `collapse = ' '`. Another possibility would be to modify `latex.summary.formula.reverse()` to collapse the legend before calling `latex.default()`, but that seemed like a less generalized solution.