### PR TITLE
[Hmisc::describe] Make `colors` as `Hmisc::html` parameter

### DIFF
--- a/R/describe.s
+++ b/R/describe.s
@@ -356,7 +356,7 @@ print.describe <-
 formatdescribeSingle <-
   function(x, condense=c('extremes', 'frequencies', 'both', 'none'),
            lang=c('plain', 'latex', 'html'), verb=0, lspace=c(0, 0),
-           size=85, ...)
+           size=85, color='MidnightBlue', ...)
 {
   condense <- match.arg(condense)
   lang     <- match.arg(lang)
@@ -394,7 +394,7 @@ formatdescribeSingle <-
     if(condense %in% c('extremes', 'both')) {
       if(lang == 'html') {
         fsize <- specs$size
-        mnb <- function(x) specs$color(x, col='MidnightBlue')
+        mnb <- function(x) specs$color(x, col=color)
         spc <- specs$space
         blo <- paste0(mnb('lowest'), spc, ':')
         bhi <- paste0(mnb('highest'),     ':')
@@ -722,7 +722,7 @@ latex.describe.single <-
 
 html.describe <-
   function(object, size=85,
-           tabular=TRUE, greek=TRUE, scroll=FALSE, rows=25, cols=100, ...)
+           tabular=TRUE, greek=TRUE, scroll=FALSE, rows=25, cols=100, color='MidnightBlue', ...)
 {
   at <- attributes(object)
 
@@ -735,7 +735,7 @@ html.describe <-
   sskip  <- m$smallskip
   hrule  <- m$hrulethin
   fsize  <- m$size
-  mnb    <- function(x) m$color(x, 'MidnightBlue')
+  mnb    <- function(x) m$color(x,  color)
 
   R <- c(m$unicode, m$style())   ## define thinhr (and others not needed here)
   
@@ -780,7 +780,7 @@ html.describe <-
 
 html.describe.single <-
   function(object, size=85,
-           tabular=TRUE, greek=TRUE, ...)
+           tabular=TRUE, greek=TRUE, color='MidnightBlue', ...)
 {
   m <- markupSpecs$html
   center <- m$center
@@ -854,7 +854,7 @@ html.describe.single <-
     colnames(d) <- names(object$counts)
     tab <- html(d, file=FALSE, align='c',
                 align.header='c', bold.header=FALSE,
-                col.header='MidnightBlue', border=0,
+                col.header=color, border=0,
                 translate=TRUE, size=sz)
     R <- c(R, tab)
   }

--- a/R/describe.s
+++ b/R/describe.s
@@ -396,8 +396,8 @@ formatdescribeSingle <-
         fsize <- specs$size
         mnb <- function(x) specs$color(x, col=color)
         spc <- specs$space
-        blo <- mnb('lowest:')
-        bhi <- mnb('highest:')
+        blo <- paste0(spc,  mnb('lowest:'))
+        bhi <- paste0(     mnb('highest:'))
         if(w + 2 <= wide) {
           low <- paste(blo, paste(val[1: 5], collapse=' '))
           hi  <- paste(bhi, paste(val[6:10], collapse=' '))
@@ -414,7 +414,7 @@ formatdescribeSingle <-
         }
       }  # end lang='html'
       else {  # lang='plain' or 'latex'
-        low <- paste('lowest:',  paste(val[1: 5], collapse=' '))
+        low <- paste(' lowest:',  paste(val[1: 5], collapse=' '))
         hi  <- paste('highest:', paste(val[6:10], collapse=' '))
         R <- c(R,
                if(w + 2 <= wide)

--- a/R/describe.s
+++ b/R/describe.s
@@ -396,8 +396,8 @@ formatdescribeSingle <-
         fsize <- specs$size
         mnb <- function(x) specs$color(x, col=color)
         spc <- specs$space
-        blo <- paste0(mnb('lowest'), spc, ':')
-        bhi <- paste0(mnb('highest'),     ':')
+        blo <- mnb('lowest:')
+        bhi <- mnb('highest:')
         if(w + 2 <= wide) {
           low <- paste(blo, paste(val[1: 5], collapse=' '))
           hi  <- paste(bhi, paste(val[6:10], collapse=' '))
@@ -414,7 +414,7 @@ formatdescribeSingle <-
         }
       }  # end lang='html'
       else {  # lang='plain' or 'latex'
-        low <- paste('lowest :', paste(val[1: 5], collapse=' '))
+        low <- paste('lowest:',  paste(val[1: 5], collapse=' '))
         hi  <- paste('highest:', paste(val[6:10], collapse=' '))
         R <- c(R,
                if(w + 2 <= wide)
@@ -757,7 +757,7 @@ html.describe <-
         next
       
       r <- html.describe.single(z, ## vname=vnames[i],
-                                tabular=tabular, greek=greek, size=size, ...)
+                                tabular=tabular, greek=greek, size=size, color=color, ...)
       R <- c(R, r, hrule)
     }
     
@@ -773,7 +773,7 @@ html.describe <-
   }
   else
     R <- c(R, html.describe.single(object, tabular=tabular,
-                                   greek=greek, size=size, ...))
+                                   greek=greek, size=size, color = color, ...))
   
   htmltools::HTML(R)
 }
@@ -862,7 +862,7 @@ html.describe.single <-
     R <- c(R, htmlVerbatim(object$counts, size=sz))
 
   
-  R <- c(R, formatdescribeSingle(object, lang='html', ...))
+  R <- c(R, formatdescribeSingle(object, lang='html', color = color, ...))
   R
 }
 


### PR DESCRIPTION
1. I suggest converting value 'MidnightBlue' into parameter `color` (which defaults to `color = 'MidnightBlue'`), so that users could be set it manually. This is helpful, for web pages and for *RStudio*  notebooks with dark backgrounds where "MidnightBlue" is barely visible.
2. The position of space corrected from "lower :" to " lower:" (as the last one follows the rules of punctuation).