### PR TITLE
candidate summaryM fix for character variables

### DIFF
--- a/R/summaryM.s
+++ b/R/summaryM.s
@@ -95,6 +95,9 @@ summaryM <- function(formula, groups=NULL, data=NULL, subset,
         labels[i] <- attr(w, "label")
       
       if(length(attr(w, 'units'))) Units[i]  <- attr(w, 'units')
+
+      if(is.character(w))
+        w <- as.factor(w)
       
       if(!inherits(w, 'mChoice')) {
         if(!is.factor(w) && !is.logical(w) &&


### PR DESCRIPTION
Frank, 

Below is a reproducible example that illustrates the error that I've had with character vectors and summaryM. This pull request is seems to fix the problem (but I haven't tested it thoroughly).

Regards,
Matt

```
## load Hmisc package
library('Hmisc')

## Hmisc version on my machine:
## "Hmisc 4.0-3 2017-04-30 /home/matt/R/x86_64-pc-linux-gnu-library/3.3"
version('Hmisc')

## create list of words to sample
word_list <- replicate(100, 
  paste0(letters[sample.int(26,10)],collapse=''))

## create data frame
dat   <- data.frame(
  strata=sample(c(T,F),1000,rep=T),
  words=sample(word_list,1000,rep=T))

## ensure that 'words' is character
## By default, it's converted to factor 
## when the data frame is created.
dat$words <- as.character(dat$words)

## call that generates error in call to 'quantile.default'
## "Error in (1 - h) * qs[i] : non-numeric argument to binary operator"
summaryM(words ~ strata, data=dat)
```
