### PR TITLE
fixes unused argument error in formatCons

### DIFF
--- a/R/summary.formula.s
+++ b/R/summary.formula.s
@@ -1661,7 +1661,7 @@ formatCons <- function(stats, nam, tr, group.freq, prmsd, sep='/',
       }
       if(prN)
         st[j] <-
-          paste0(st[j], outer.size(paste0(spc, math('N=', cqu[j, ncol(cqu)]))))
+          paste0(st[j], outer.size(paste0(spc, math(paste0('N=', cqu[j, ncol(cqu)])))))
     }
   } else {
     if(prmsd) {


### PR DESCRIPTION
Hi Frank, 

This commit fixes an error associated with the prN=TRUE argument when latex'ing the result of summaryM:

```
###### original ######

> latex(summaryM(Petal.Width ~ Species, data=iris), prN=TRUE, file="")
Error in math("N=", cqu[j, ncol(cqu)]) : 
  unused argument (cqu[j, ncol(cqu)])

###### after patch ######

>  latex(summaryM(Petal.Width ~ Species, data=iris), prN=TRUE, file="")
%latex.default(cstats, title = title, file = file, append = TRUE,     caption = finalcaption, rowlabel = rowlabel, table.env = (!tabenv1 &&         table.env) || (tabenv1 && istr == 1), col.just = col.just,     numeric.dollar = FALSE, insert.bottom = finallegend, rowname = lab,     dcolumn = dcolumn, extracolheads = extracolheads, extracolsize = NNsize,     insert.top = if (strat != ".ALL.") strat, ...)%
\begin{table}[!tbp]
\caption{Descriptive Statistics$  (N=150)$. {\scriptsize $a$} $b$ {\scriptsize $c$} represent the lower quartile $a$, the median $b$, and the upper quartile $c$ for continuous variables.\label{summaryM}} 
\begin{center}
\begin{tabular}{lccc}
\hline\hline
\multicolumn{1}{l}{}&\multicolumn{1}{c}{setosa}&\multicolumn{1}{c}{versicolor}&\multicolumn{1}{c}{virginica}\tabularnewline
&\multicolumn{1}{c}{{\scriptsize $N=50$}}&\multicolumn{1}{c}{{\scriptsize $N=50$}}&\multicolumn{1}{c}{{\scriptsize $N=50$}}\tabularnewline
\hline
Petal.Width&{\scriptsize 0.2} 0.2 {\scriptsize 0.3}{\scriptsize ~$N=50$}&{\scriptsize 1.2} 1.3 {\scriptsize 1.5}{\scriptsize ~$N=50$}&{\scriptsize 1.8} 2.0 {\scriptsize 2.3}{\scriptsize ~$N=50$}\tabularnewline
\hline
\end{tabular}\end{center}
\end{table}
```