### PR TITLE
restore all the classes on [.describe

### DIFF
--- a/R/describe.s
+++ b/R/describe.s
@@ -528,7 +528,7 @@ print.describe.single <-
   object <- '['(unclass(object),i)
   structure(object, descript=at$descript,
             dimensions=c(at$dimensions[1], length(object)),
-            class='describe')
+            class=class(object))
 }
 
 


### PR DESCRIPTION
I believe this caused the package `neuropsychology` to fail against dplyr 1.0.0 because a data frame with additional class `describe` is `[` and this method only keeps "describe" as the class. 

closes https://github.com/tidyverse/dplyr/issues/5240

