### PR TITLE
weighted quantile bug fix

### DIFF
--- a/R/wtd.stats.s
+++ b/R/wtd.stats.s
@@ -70,16 +70,8 @@ wtd.quantile <- function(x, weights=NULL, probs=c(0, .25, .5, .75, 1),
     x     <- w$x
     wts   <- w$sum.of.weights
     n     <- sum(wts)
-    order <- 1 + (n - 1) * probs
-    low   <- pmax(floor(order), 1)
-    high  <- pmin(low + 1, n)
-    order <- order %% 1
-    ## Find low and high order statistics
-    ## These are minimum values of x such that the cum. freqs >= c(low,high)
-    allq <- approx(cumsum(wts), x, xout=c(low,high), 
+    quantiles <- approx(cumsum(wts), x, xout=probs*n, 
                    method='constant', f=1, rule=2)$y
-    k <- length(probs)
-    quantiles <- (1 - order)*allq[1:k] + order*allq[-(1:k)]
     names(quantiles) <- nams
     return(quantiles)
   } 

--- a/R/wtd.stats.s
+++ b/R/wtd.stats.s
@@ -71,7 +71,7 @@ wtd.quantile <- function(x, weights=NULL, probs=c(0, .25, .5, .75, 1),
     wts   <- w$sum.of.weights
     n     <- sum(wts)
     quantiles <- approx(cumsum(wts), x, xout=probs*n, 
-                   method='constant', f=1, rule=2)$y
+                   method='linear', f=1, rule=2)$y
     names(quantiles) <- nams
     return(quantiles)
   } 

--- a/R/wtd.stats.s
+++ b/R/wtd.stats.s
@@ -69,8 +69,17 @@ wtd.quantile <- function(x, weights=NULL, probs=c(0, .25, .5, .75, 1),
     w <- wtd.table(x, weights, na.rm=na.rm, normwt=normwt, type='list')
     x     <- w$x
     wts   <- w$sum.of.weights
-    n     <- sum(wts)
-    quantiles <- approx(cumsum(wts), x, xout=probs*n, 
+    weighted_S = c()
+    cum_w <- cumsum(wts)
+    for (i in c(1:length(wts))){
+      if (i > 1){
+        Sk = (i-1) * wts[i] + (length(wts)-1) * cum_w[i-1]}
+      else{
+        Sk = 0
+      }
+      weighted_S = append(weighted_S, Sk)
+    }
+    allq <- approx(weighted_S, x, xout=probs*weighted_S[length(weighted_S)], 
                    method='linear', f=1, rule=2)$y
     names(quantiles) <- nams
     return(quantiles)


### PR DESCRIPTION
Original code has two problems:
1. When normwt = FALSE and weight sum < 1.
![image](https://user-images.githubusercontent.com/67881762/88069113-a5cced80-cba3-11ea-821a-6e376edc35ef.png)

This line goes wrong. The indexing becomes descending. 

2. It sees the lowest index as 1.
![image](https://user-images.githubusercontent.com/67881762/88069068-9057c380-cba3-11ea-9aa6-690828b16733.png)

For example:
```sh
> data <- 1:3
> weights<- c(0.1, 0.1, 0.8)
> probs=0.09
 
 wtd.quantile(x=data, weights=weights, probs=probs, normwt=TRUE)
9% 
3 
```
It is because the cumsum is 0.3, 0.6, 3.0 and the approx function try to locate lower index 1 and upper index 2.
It turns both q take the 3 value and the interpolation crush.

I find one formula to define weighted quantile.
https://stats.stackexchange.com/questions/13169/defining-quantiles-over-a-weighted-sample
It is well defined in boundary and the result equals to numpy quantile when weights are equal.
I implement the code accordingly and this one doesn't have the above mentioned problem.

Any review is welcome.