### PR TITLE
include proportion when describe creates table values

### DIFF
--- a/R/describe.s
+++ b/R/describe.s
@@ -543,8 +543,17 @@ formatdescribeSingle <-
              paste('For the frequency table, variable is rounded to the nearest',
                    format(x$roundedTo, scientific=3)))
     
-  } else if(length(v) && ! is.standard)
-    R <- c(R, '', vbtm(v))
+  } else if(length(v) && ! is.standard) {
+    if(inherits(v, 'table')) {
+      fval <- names(v)
+      freq <- unname(v)
+      prop <- round(freq / sum(freq), 3)
+      w <- sprintf('%s (%s, %s)', names(v), format(freq), format(prop))
+      R <- c(R, '', w)
+    } else {
+      R <- c(R, '', vbtm(v))
+    }
+  }
   
   if(length(x$mChoice)) {
     R <- c(R, bv()); verb <- 1


### PR DESCRIPTION
I'm not certain on how the output should be formatted, but this should support issue #193.

This is what plain text output would look like with the change:
```
> Hmisc::describe(paste("long long long long long variable name", letters[1:10]), listunique = 20)
paste("long long long long long variable name", letters[1:10]) 
       n  missing distinct 
      10        0       10 

lowest : long long long long long variable name a long long long long long variable name b long long long long long variable name c long long long long long variable name d long long long long long variable name e
highest: long long long long long variable name f long long long long long variable name g long long long long long variable name h long long long long long variable name i long long long long long variable name j

long long long long long variable name a (1, 0.1)
long long long long long variable name b (1, 0.1)
long long long long long variable name c (1, 0.1)
long long long long long variable name d (1, 0.1)
long long long long long variable name e (1, 0.1)
long long long long long variable name f (1, 0.1)
long long long long long variable name g (1, 0.1)
long long long long long variable name h (1, 0.1)
long long long long long variable name i (1, 0.1)
long long long long long variable name j (1, 0.1)
```