### PR TITLE
unix and windows sas.get.Rd

### DIFF
--- a/man/windows/sas.get.Rd
+++ b/man/windows/sas.get.Rd
@@ -6,6 +6,7 @@
 \alias{format.special.miss}
 \alias{sas.codes}
 \alias{code.levels}
+alias{timePOSIXt}
 \title{Convert a SAS Dataset to an S Data Frame}
 \description{
   Converts a \acronym{SAS} dataset into an S data frame.  


### PR DESCRIPTION
The windows and linux documentation help page of sas.get.Rd differ on the alias they use.
This patch unifies that by adding the alias to windows. 

Not totally sure why this is the only difference (I expected a difference on the text but I couldn't find any).
This could also be resolved by moving either of the help files to the main `man/` directory (and deleting the other file).
Here there is a minimal patch to add the alias to the windows file.  