### PR TITLE
Remove plyr dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Authors@R:
 Maintainer: Frank E Harrell Jr <fh@fharrell.com>
 Depends: R (>= 4.2.0)
 Imports: methods, ggplot2, cluster, rpart, nnet, foreign, gtable, grid, gridExtra, data.table, htmlTable (>= 1.11.0), viridis, htmltools, base64enc, colorspace, rmarkdown, knitr, Formula
-Suggests: survival, qreport, acepack, chron, rms, mice, rstudioapi, tables, plotly (>= 4.5.6), rlang, plyr, VGAM, leaps, pcaPP, digest, parallel, polspline, abind, kableExtra, rio, lattice, latticeExtra, gt, sparkline, jsonlite, htmlwidgets, qs, getPass, keyring, safer, htm2txt
+Suggests: survival, qreport, acepack, chron, rms, mice, rstudioapi, tables, plotly (>= 4.5.6), rlang, VGAM, leaps, pcaPP, digest, parallel, polspline, abind, kableExtra, rio, lattice, latticeExtra, gt, sparkline, jsonlite, htmlwidgets, qs, getPass, keyring, safer, htm2txt
 Description: Contains many functions useful for data
 	analysis, high-level graphics, utility operations, functions for
 	computing sample size and power, simulation, importing and annotating datasets,

--- a/R/stat-plsmo.r
+++ b/R/stat-plsmo.r
@@ -66,6 +66,9 @@ StatPlsmo <- ggplot2::ggproto("StatPlsmo", ggplot2::Stat,
 
   setup_data = function(data, params) {
     rows <- tapply(data$x, data$group, \(x) length(unique(x)))
+    if (anyNA(data$group)) {
+      rows <- c(length(unique(data$x[is.na(data$group)])), rows)
+    }
 
     if (all(rows == 1) && length(rows) > 1) {
       message("geom_plsmo: Only one unique x value each group.",

--- a/R/stat-plsmo.r
+++ b/R/stat-plsmo.r
@@ -65,7 +65,7 @@ StatPlsmo <- ggplot2::ggproto("StatPlsmo", ggplot2::Stat,
   required_aes = c("x", "y"),
 
   setup_data = function(data, params) {
-    rows <- tapply(data$x, data$group, function(x) length(unique(x)))
+    rows <- tapply(data$x, data$group, \(x) length(unique(x)))
 
     if (all(rows == 1) && length(rows) > 1) {
       message("geom_plsmo: Only one unique x value each group.",

--- a/R/stat-plsmo.r
+++ b/R/stat-plsmo.r
@@ -65,9 +65,7 @@ StatPlsmo <- ggplot2::ggproto("StatPlsmo", ggplot2::Stat,
   required_aes = c("x", "y"),
 
   setup_data = function(data, params) {
-    if (!requireNamespace("plyr", quietly = TRUE))
-      stop("This function requires the 'plyr' package.")
-    rows <- plyr::daply(data, "group", function(df) length(unique(df$x)))
+    rows <- tapply(data$x, data$group, function(x) length(unique(x)))
 
     if (all(rows == 1) && length(rows) > 1) {
       message("geom_plsmo: Only one unique x value each group.",


### PR DESCRIPTION
{plyr} is long superseded; in this case, there is a simple base alternative, and this is the only place plyr is used.