### PR TITLE
Change 'x' argument for clarity in 'html_describe_con' internal helper 'g'

### DIFF
--- a/R/describe.s
+++ b/R/describe.s
@@ -1431,12 +1431,12 @@ html_describe_con <- function(x, sparkwidth=200,
   ## If the variable was transformed, also put in the leftmost tooltip
   ## the name of the transformation
   
-  g <- function(x) {
-    trans <- x$trans
+  g <- function(u) {
+    trans <- u$trans
     lo <- if(length(trans))
             paste0('Transformation for<br>histogram:', trans[[1]])
     
-    gv <- x$gridvalues
+    gv <- u$gridvalues
     val <- gsub('; ', '<br>', gv$values)
     spikespark(val, gv$frequency, ttlow=lo, w=sparkwidth, cumulative=TRUE,
                xpre='')


### PR DESCRIPTION
This is being flagged by CRAN:

```
  html_describe_con: multiple local function definitions for ‘g’ with
    different formal arguments
```

I'm not sure it's the most useful CRAN flag, but OTOH, we _do_ have `x` as an argument to `html_describe_con` _and_ its internal helper, which is somewhat confusing. Basically we do this:

```
sapply(x, function(x) ...)
```

I think it's preferable to avoid reusing `x` like that, so I chose `u` since `g` above uses the same.

Alternatively, we could give these internal helpers a more descriptive name than just `g`.