### PR TITLE
Sync formals of deb with/without 'opt'

### DIFF
--- a/R/Fdebug.r
+++ b/R/Fdebug.r
@@ -37,6 +37,6 @@ Fdebug <- function(opt) {
   formals(deb)$txt <- opt
   formals(deb)$callingfun <- as.character(sys.call(-1)[1])
   }
-  else deb <- function(x, txt, callingfun, file) {NULL}
+  else deb <- function(x, txt, callingfun, file=getOption('debug_file', '')) {NULL}
   deb
 }


### PR DESCRIPTION
Same issue as #203.

Another approach would be to hide it (as is being done with `formals(deb)$txt`), but I didn't want to test whether we need to `quote()` the input.